### PR TITLE
Update full_example.yaml with device connected status

### DIFF
--- a/full_example.yaml
+++ b/full_example.yaml
@@ -48,3 +48,7 @@ sensor:
       name: "IGrill v3 temp 4"
     propane_level:
       name: "IGrill v3 Propane"
+ 
+ binary_sensor:
+  - platform: status
+    name: "iGrill Adapter Status"


### PR DESCRIPTION
Add binary sensor in order for HA to tell if the ESPHome device is connected or disconnected. This allows for easy conditional cards - i.e. hide the probes if the device is offline.

![image](https://github.com/pieslinger/esphome-igrill/assets/87915068/c5167fdc-49d3-4efe-a870-cb1d694994f1)
